### PR TITLE
fix: Change EditContentHeader to be able to custom buttons

### DIFF
--- a/src/components/Edit/EditContentHeader.jsx
+++ b/src/components/Edit/EditContentHeader.jsx
@@ -31,16 +31,24 @@ const EditContainerDivider = styled.div`
   background-color: ${({ theme }) => theme.colors.gray200};
 `;
 
-const EditContentHeader = ({ title, onCancel, onSubmit, isEditMode }) => {
+const EditContentHeader = ({ title, buttonsData = [] }) => {
   return (
     <EditContentHeaderLayout>
       <EditContentHeaderSection>
         <EditContentHeaderText>{title}</EditContentHeaderText>
         <EditContentHeaderActions>
-          <ButtonBase onClick={onCancel}>취소</ButtonBase>
-          <ButtonBase onClick={onSubmit} $isHighlighted={true}>
-            {isEditMode ? "수정" : "저장"}
-          </ButtonBase>
+          {buttonsData.map((item, index) => {
+            return (
+              <ButtonBase
+                key={index}
+                $isHighlighted={index == buttonsData.length - 1}
+                onClick={item.onClick}
+              >
+                {item.icon}
+                {item.value}
+              </ButtonBase>
+            );
+          })}
         </EditContentHeaderActions>
       </EditContentHeaderSection>
       <EditContainerDivider />
@@ -50,9 +58,13 @@ const EditContentHeader = ({ title, onCancel, onSubmit, isEditMode }) => {
 
 EditContentHeader.propTypes = {
   title: PropTypes.string.isRequired,
-  onCancel: PropTypes.func,
-  onSubmit: PropTypes.func,
-  isEditMode: PropTypes.bool,
+  buttonsData: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      onClick: PropTypes.func,
+      icon: PropTypes.element,
+    })
+  ),
 };
 
 export { EditContentHeader };

--- a/src/components/Edit/EditContentHeader.jsx
+++ b/src/components/Edit/EditContentHeader.jsx
@@ -44,7 +44,6 @@ const EditContentHeader = ({ title, buttonsData = [] }) => {
                 $isHighlighted={index == buttonsData.length - 1}
                 onClick={item.onClick}
               >
-                {item.icon}
                 {item.value}
               </ButtonBase>
             );
@@ -62,7 +61,6 @@ EditContentHeader.propTypes = {
     PropTypes.shape({
       value: PropTypes.string.isRequired,
       onClick: PropTypes.func,
-      icon: PropTypes.element,
     })
   ),
 };


### PR DESCRIPTION
- untitled-ui 에서 EditContentHeader의 button을 페이지 별로 custom이 가능하게끔 수정
- 기존은 버튼이 이 코드에서 정해졌다면, 사용하는 페이지에서 buttonsData를 만들어서 사용 가능

- close #1 